### PR TITLE
Enable computeChecksums instead of providing ContentMD5

### DIFF
--- a/src/lib/s3-helper.js
+++ b/src/lib/s3-helper.js
@@ -131,7 +131,6 @@ class S3Helper {
       ACL: 'public-read',
       Key: fileName,
       Body: shouldBeZipped ? gzipStream(fStream) : fStream,
-      ContentMD5: Buffer.from(toUpload.hashes[fileName], 'hex').toString('base64'),
     };
 
     if (contentType) {

--- a/src/steps.js
+++ b/src/steps.js
@@ -162,6 +162,7 @@ module.exports.detectFileChanges = (localHashes, remoteHashes) => {
 module.exports.configureAwsSdk = params => {
   logger.info('▹ Configuring AWS SDK');
   const awsOptions = {
+    computeChecksums: true,
     sslEnabled: true,
     region: params.region,
   };

--- a/test/steps.spec.js
+++ b/test/steps.spec.js
@@ -325,6 +325,7 @@ describe('Steps', () => {
         region: 'awsRegion',
       };
       const expectedOptions = Object.assign({
+        computeChecksums: true,
         sslEnabled: true,
       }, params);
       const configuredAws = steps.configureAwsSdk(params);
@@ -344,7 +345,10 @@ describe('Steps', () => {
 
     test('sets region and profile for aws sdk module', () => {
       const params = { region: 'awsRegion', profile: 'profile' };
-      const expectedOptions = Object.assign({ sslEnabled: true }, params);
+      const expectedOptions = Object.assign({
+        computeChecksums: true,
+        sslEnabled: true,
+      }, params);
       delete expectedOptions.profile;
 
       const sharedCredentialsMock = { cred: 'val' };


### PR DESCRIPTION
#1 
I encounter the same problem when the file size is larger than 5MB. aws-cli will automatically use multi-part upload. And because the request data is chucked, the MD5 is not valid. There's an issue for it at aws-cli repo and the official suggestion is to let aws-cli calculation the hash for you.

https://github.com/aws/aws-sdk-js/issues/774#issuecomment-155837412